### PR TITLE
Add trace on error for PhantomJS

### DIFF
--- a/lib/engines/phantom.js
+++ b/lib/engines/phantom.js
@@ -41,8 +41,12 @@ PhantomEngine.prototype.init = function(appUrl, initCallback, errorCallback, bef
 
       _this.phantom.page.set('onCallback', _.bind(_this.onPageReady, _this));
 
-      _this.phantom.page.set('onError', function(msg) {
-        errorCallback("Phantom encountered an error: " + msg);
+      _this.phantom.page.set('onError', function(msg, trace) {
+        var error = msg;
+        if(trace.length) {
+          error += "\n" + JSON.stringify(trace, null, 2);
+        }
+        errorCallback("Phantom encountered an error: " + error);
       });
 
       // FIXME: Uncomment after resolving issue in phantomjs-node (https://github.com/sgentle/phantomjs-node/issues/203)


### PR DESCRIPTION
For me and for most of developers hard to find problem when it presented like this `Phantom encountered an error: SyntaxError: Parse error`.

Here is a [reference](http://phantomjs.org/api/phantom/handler/on-error.html).